### PR TITLE
fix: replace fmt.Println with structured logging and fix race conditions

### DIFF
--- a/internal/apis/admin_permissions.go
+++ b/internal/apis/admin_permissions.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
@@ -147,7 +146,6 @@ func (api *Api) AdminPermissionsList(ctx context.Context, input *struct {
 	PermissionsListParams
 }) (*ApiPaginatedOutput[*Permission], error) {
 	store := api.App().Adapter().Rbac()
-	fmt.Println(input)
 	filter := new(stores.PermissionFilter)
 	filter.Page = input.Page
 	filter.PerPage = input.PerPage

--- a/internal/apis/api_bind.go
+++ b/internal/apis/api_bind.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -60,7 +59,6 @@ func bindMiscApi(appApi *Api) {
 	huma.Get(api, "/", func(ctx context.Context, input *struct {
 		Page types.OmittableNullable[string] `query:"page" required:"false"`
 	}) (*IndexOutput, error) {
-		fmt.Println("input", input)
 		return &IndexOutput{
 			Body: IndexOutputBody{
 				Access: "public",

--- a/internal/services/notifier_team.go
+++ b/internal/services/notifier_team.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -295,7 +294,7 @@ func (d *DbNotifier) NotifyTaskDueToday(ctx context.Context, taskID uuid.UUID) e
 	taskEndAtIsNow := isWithinPastHours(task.EndAt, 24*time.Hour)
 
 	if taskEndAtIsNow {
-		fmt.Println("task due today")
+		slog.DebugContext(ctx, "task due today", slog.String("task_id", task.ID.String()))
 		payload := notification.TaskDueTodayNotificationData{
 			TaskID:  task.ID,
 			DueDate: *task.EndAt,
@@ -321,7 +320,7 @@ func (d *DbNotifier) NotifyTaskDueToday(ctx context.Context, taskID uuid.UUID) e
 			notifyMemberIds = append(notifyMemberIds, *task.CreatedByMemberID)
 		}
 		if len(notifyMemberIds) == 0 {
-			fmt.Println("no members to notify")
+			slog.DebugContext(ctx, "no members to notify", slog.String("task_id", task.ID.String()))
 			return nil
 		}
 		notifyMembers, err := d.adapter.TeamMember().FindTeamMembers(ctx, &stores.TeamMemberFilter{
@@ -361,7 +360,7 @@ func (d *DbNotifier) NotifyTaskDueToday(ctx context.Context, taskID uuid.UUID) e
 			return err
 		}
 	} else {
-		fmt.Println("task is not due today")
+		slog.DebugContext(ctx, "task is not due today", slog.String("task_id", task.ID.String()))
 		return nil
 	}
 	return nil
@@ -380,7 +379,7 @@ func (d *DbNotifier) NotifyTaskCompleted(ctx context.Context, taskID uuid.UUID, 
 	}
 	// 2. check task end at is now
 
-	fmt.Println("task due today")
+	slog.DebugContext(ctx, "task completed, notifying", slog.String("task_id", taskID.String()))
 	payload := notification.TaskCompletedNotificationData{
 		TaskID:              taskID,
 		CompletedByMemberID: completedByMemberID,
@@ -407,7 +406,7 @@ func (d *DbNotifier) NotifyTaskCompleted(ctx context.Context, taskID uuid.UUID, 
 		notifyMemberIds = append(notifyMemberIds, *task.CreatedByMemberID)
 	}
 	if len(notifyMemberIds) == 0 {
-		fmt.Println("no members to notify")
+		slog.DebugContext(ctx, "no members to notify", slog.String("task_id", taskID.String()))
 		return nil
 	}
 	notifyMembers, err := d.adapter.TeamMember().FindTeamMembers(ctx, &stores.TeamMemberFilter{

--- a/internal/services/payment_service.go
+++ b/internal/services/payment_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"strconv"
 
@@ -345,9 +344,9 @@ func (srv *StripeService) Client() PaymentClient {
 }
 
 func (srv *StripeService) SyncPerms(ctx context.Context) error {
-	var err error
+	var errs []error
 	for productId, permission := range shared.StripeProductPermissionMap {
-		err = func() error {
+		err := func() error {
 			product, err := srv.adapter.Product().FindProduct(ctx, &stores.StripeProductFilter{
 				Ids: []string{productId},
 			})
@@ -366,17 +365,20 @@ func (srv *StripeService) SyncPerms(ctx context.Context) error {
 			}
 			return srv.adapter.Rbac().CreateProductPermissions(ctx, product.ID, perm.ID)
 		}()
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 func (srv *StripeService) UpsertPriceProductFromStripe(ctx context.Context) error {
 	if err := srv.FindAndUpsertAllProducts(ctx); err != nil {
-		fmt.Println(err)
+		srv.logger.Error("error upserting products", "error", err)
 		return err
 	}
 	if err := srv.FindAndUpsertAllPrices(ctx); err != nil {
-		fmt.Println(err)
+		srv.logger.Error("error upserting prices", "error", err)
 		return err
 	}
 	return nil
@@ -629,7 +631,7 @@ func (srv *StripeService) CreateBillingPortalSession(ctx context.Context, stripe
 	}
 	url, err := srv.client.CreateBillingPortalSession(stripeCustomerId, config, returnUrl)
 	if err != nil {
-		log.Println(err)
+		srv.logger.Error("error creating billing portal session", "error", err)
 		return "", errors.New("failed to create checkout session")
 	}
 	if url == nil {

--- a/internal/services/team_service.go
+++ b/internal/services/team_service.go
@@ -79,7 +79,7 @@ func (t *TeamServiceImpl) ProcessSlug(ctx context.Context, teamSlug string, team
 		return randomSlug, nil
 	}
 	uuidSlug := uuid.NewString()
-	uuidSlugTeam, err := t.adapter.TeamGroup().FindTeamBySlug(ctx, randomSlug)
+	uuidSlugTeam, err := t.adapter.TeamGroup().FindTeamBySlug(ctx, uuidSlug)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/sse/manager.go
+++ b/internal/tools/sse/manager.go
@@ -27,6 +27,8 @@ type manager struct {
 
 // Send implements Manager.
 func (m *manager) Send(channel string, data any) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	var errs []error
 	for c := range m.clients {
 		if c == nil {
@@ -48,6 +50,8 @@ func (m *manager) Send(channel string, data any) error {
 
 // SendAll implements Manager.
 func (m *manager) SendAll(data any) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	var errs []error
 	for c := range m.clients {
 		if err := c.Write(Message{Data: data}); err != nil {

--- a/internal/tools/ttlmap/ttlmap.go
+++ b/internal/tools/ttlmap/ttlmap.go
@@ -13,30 +13,42 @@ type item struct {
 
 // You can have a single map for an application or few maps for different purposes
 type TTLMap struct {
-	m map[string]*item
-	// For safe access to the map
-	mu sync.Mutex
+	m    map[string]*item
+	mu   sync.Mutex
+	stop chan struct{}
 }
 
-func New(size int, maxTTL int) (m *TTLMap) {
-	// map is created with the given length
-	m = &TTLMap{m: make(map[string]*item, size)}
+func New(size int, maxTTL int) *TTLMap {
+	m := &TTLMap{
+		m:    make(map[string]*item, size),
+		stop: make(chan struct{}),
+	}
 
-	// this goroutine will clean up the map from old items
+	ticker := time.NewTicker(time.Second)
 	go func() {
-		// You can adjust this ticker to be more or less frequent
-		for now := range time.Tick(time.Second) {
-			m.mu.Lock()
-			for k, v := range m.m {
-				if now.Unix()-v.lastAccess > int64(maxTTL) {
-					delete(m.m, k)
+		defer ticker.Stop()
+		for {
+			select {
+			case now := <-ticker.C:
+				m.mu.Lock()
+				for k, v := range m.m {
+					if now.Unix()-v.lastAccess > int64(maxTTL) {
+						delete(m.m, k)
+					}
 				}
+				m.mu.Unlock()
+			case <-m.stop:
+				return
 			}
-			m.mu.Unlock()
 		}
 	}()
 
-	return
+	return m
+}
+
+// Close stops the background cleanup goroutine.
+func (m *TTLMap) Close() {
+	close(m.stop)
 }
 
 // Put adds a new item to the map or updates the existing one


### PR DESCRIPTION
  - SyncPerms now collects all errors instead of returning on first
  - team_service: fix slug lookup using uuidSlug instead of randomSlug
  - SSE Send/SendAll missing RLock causing data race
  - TTLMap goroutine leak; add stop channel and Close()