### PR TITLE
refactor(database): replace stephenafamo/scan with native pgx scanning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.10.2
-	github.com/stephenafamo/scan v0.7.0
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v82 v82.5.1
 	github.com/wneessen/go-mail v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,6 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/ThreeDotsLabs/watermill v1.5.1 h1:t5xMivyf9tpmU3iozPqyrCZXHvoV1XQDfihas4sV0fY=
 github.com/ThreeDotsLabs/watermill v1.5.1/go.mod h1:Uop10dA3VeJWsSvis9qO3vbVY892LARrKAdki6WtXS4=
-github.com/aarondl/json v0.0.0-20221020222930-8b0db17ef1bf h1:+edM69bH/X6JpYPmJYBRLanAMe1V5yRXYU3hHUovGcE=
-github.com/aarondl/json v0.0.0-20221020222930-8b0db17ef1bf/go.mod h1:FZqLhJSj2tg0ZN48GB1zvj00+ZYcHPqgsC7yzcgCq6k=
-github.com/aarondl/opt v0.0.0-20221129170750-3d40c96d9bb8 h1:pAJut2Ye6sxwIS8zQvu1BhX87B+9MwUKmzjdEkwPWg4=
-github.com/aarondl/opt v0.0.0-20221129170750-3d40c96d9bb8/go.mod h1:l4/5NZtYd/SIohsFhaJQQe+sPOTG22furpZ5FvcYOzk=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
@@ -173,10 +169,6 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97 h1:XItoZNmhOih06TC02jK7l3wlpZ0XT/sPQYutDcGOQjg=
-github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97/go.mod h1:bM3Vmw1IakoaXocHmMIGgJFYob0vuK+CFWiJHQvz0jQ=
-github.com/stephenafamo/scan v0.7.0 h1:lfFiD9H5+n4AdK3qNzXQjj2M3NfTOpmWBIA39NwB94c=
-github.com/stephenafamo/scan v0.7.0/go.mod h1:FhIUJ8pLNyex36xGFiazDJJ5Xry0UkAi+RkWRrEcRMg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/database/exec.go
+++ b/internal/database/exec.go
@@ -2,11 +2,13 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
+	"strings"
+	"sync"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/stephenafamo/scan"
-	"github.com/stephenafamo/scan/pgxscan"
 )
 
 type QueryBuilder interface {
@@ -15,40 +17,69 @@ type QueryBuilder interface {
 
 func QueryWithBuilder[T any](ctx context.Context, db Dbx, query QueryBuilder) ([]T, error) {
 	sql, args, err := query.ToSql()
-	// fmt.Println("query", sql, "args", args)
-
 	slog.DebugContext(ctx, "Query With Builder:", slog.String("query", sql), slog.Any("args", args))
 	if err != nil {
 		return nil, err
 	}
 	return QueryAll[T](ctx, db, sql, args...)
 }
+
 func ExecWithBuilder(ctx context.Context, db Dbx, query QueryBuilder) (int64, error) {
 	sql, args, err := query.ToSql()
 	if err != nil {
 		return 0, err
 	}
 	slog.DebugContext(ctx, "Exec With Builder:", slog.String("query", sql), slog.Any("args", args))
-	result, err := Exec(ctx, db, sql, args...)
-	return result, err
+	return Exec(ctx, db, sql, args...)
 }
 
 func QueryAll[T any](ctx context.Context, db Dbx, query string, args ...any) ([]T, error) {
 	ctxDbx := GetContextOrDefaultDbx(ctx, db)
-	return pgxscan.All(ctx, ctxDbx, scan.StructMapper[T](), query, args...)
+	rows, err := ctxDbx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, rowToStructByDBTag[T])
+}
+
+// QueryOne executes a query and scans the single result row into T using db struct tags.
+// Returns pgx.ErrNoRows if the query returns no rows.
+func QueryOne[T any](ctx context.Context, db Dbx, query string, args ...any) (T, error) {
+	ctxDbx := GetContextOrDefaultDbx(ctx, db)
+	rows, err := ctxDbx.Query(ctx, query, args...)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return pgx.CollectOneRow(rows, rowToStructByDBTag[T])
 }
 
 func Count(ctx context.Context, db Dbx, query string, args ...any) (int64, error) {
 	ctxDbx := GetContextOrDefaultDbx(ctx, db)
-	return pgxscan.One(ctx, ctxDbx, scan.SingleColumnMapper[int64], query, args...)
+	rows, err := ctxDbx.Query(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return pgx.CollectOneRow(rows, pgx.RowTo[int64])
 }
+
 func QueryOneSingleColumn[T any](ctx context.Context, db Dbx, query string, args ...any) (T, error) {
 	ctxDbx := GetContextOrDefaultDbx(ctx, db)
-	return pgxscan.One(ctx, ctxDbx, scan.SingleColumnMapper[T], query, args...)
+	rows, err := ctxDbx.Query(ctx, query, args...)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return pgx.CollectOneRow(rows, pgx.RowTo[T])
 }
+
 func QueryManySingleColumn[T any](ctx context.Context, db Dbx, query string, args ...any) ([]T, error) {
 	ctxDbx := GetContextOrDefaultDbx(ctx, db)
-	return pgxscan.All(ctx, ctxDbx, scan.SingleColumnMapper[T], query, args...)
+	rows, err := ctxDbx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowTo[T])
 }
 
 func Exec(ctx context.Context, db Dbx, query string, args ...any) (int64, error) {
@@ -60,8 +91,9 @@ func Exec(ctx context.Context, db Dbx, query string, args ...any) (int64, error)
 	return result.RowsAffected(), nil
 }
 
+// CountOutput is used by QueryWithBuilder-based count queries.
 type CountOutput struct {
-	Count int64
+	Count int64 `db:"count"`
 }
 
 func PgxQueryRowsToStruct[T any](ctx context.Context, db Dbx, query QueryBuilder) ([]*T, error) {
@@ -77,6 +109,7 @@ func PgxQueryRowsToStruct[T any](ctx context.Context, db Dbx, query QueryBuilder
 	}
 	return pgx.CollectRows(r, pgx.RowToAddrOfStructByNameLax[T])
 }
+
 func PgxQuerySingleScalar[T comparable](ctx context.Context, db Dbx, query QueryBuilder) (T, error) {
 	ctxDbx := GetContextOrDefaultDbx(ctx, db)
 	var zero T
@@ -97,4 +130,122 @@ func PgxQuerySingleScalar[T comparable](ctx context.Context, db Dbx, query Query
 		return zero, nil
 	}
 	return res[0], nil
+}
+
+// dbTagCache caches column-name → field-index mappings keyed by struct reflect.Type.
+// All db-tagged fields are included (both scalar and relation fields).
+// Relation fields are used as intermediate navigation nodes for dot-path column aliases.
+var dbTagCache sync.Map
+
+// buildDBTagIndex returns a map from db tag name to struct field index for t.
+// Skips the blank info field ("_") and fields with no/empty/"-" db tag.
+// Relation fields (those with a "table" tag) are included so they can serve
+// as intermediate nodes when resolving dotted column aliases like "price.id".
+func buildDBTagIndex(t reflect.Type) map[string]int {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if cached, ok := dbTagCache.Load(t); ok {
+		return cached.(map[string]int)
+	}
+	m := make(map[string]int, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Name == "_" {
+			continue
+		}
+		tag := f.Tag.Get("db")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if comma := strings.IndexByte(tag, ','); comma != -1 {
+			tag = tag[:comma]
+		}
+		if tag != "" {
+			m[tag] = i
+		}
+	}
+	dbTagCache.Store(t, m)
+	return m
+}
+
+// resolveFieldAddr follows path into v (an addressable struct Value), allocating any
+// nil pointer structs it traverses, and returns the scan destination address.
+func resolveFieldAddr(v reflect.Value, path []string) (any, bool) {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, false
+	}
+
+	tagIndex := buildDBTagIndex(v.Type())
+	fieldIdx, ok := tagIndex[path[0]]
+	if !ok {
+		return nil, false
+	}
+	fieldVal := v.Field(fieldIdx)
+
+	if len(path) == 1 {
+		return fieldVal.Addr().Interface(), true
+	}
+	return resolveFieldAddr(fieldVal, path[1:])
+}
+
+// rowToStructByDBTag is a pgx.RowToFunc that scans a row into T using "db" struct tags.
+// T may be a struct value or a pointer to a struct.
+// Dot-separated column aliases (e.g. "stripe_customer.id") are resolved as nested struct paths.
+func rowToStructByDBTag[T any](row pgx.CollectableRow) (T, error) {
+	tType := reflect.TypeOf((*T)(nil)).Elem()
+
+	isPtr := tType.Kind() == reflect.Ptr
+	structType := tType
+	if isPtr {
+		structType = tType.Elem()
+	}
+	if structType.Kind() != reflect.Struct {
+		var zero T
+		return zero, fmt.Errorf("rowToStructByDBTag: T must be a struct or *struct, got %v", tType)
+	}
+
+	structVal := reflect.New(structType).Elem()
+
+	descs := row.FieldDescriptions()
+	dests := make([]any, len(descs))
+	for i, desc := range descs {
+		parts := strings.Split(desc.Name, ".")
+		addr, ok := resolveFieldAddr(structVal, parts)
+		if ok {
+			dests[i] = addr
+		} else {
+			var discard any
+			dests[i] = &discard
+		}
+	}
+
+	if err := row.Scan(dests...); err != nil {
+		var zero T
+		return zero, err
+	}
+
+	if isPtr {
+		ptr := reflect.New(structType)
+		ptr.Elem().Set(structVal)
+		result, ok := ptr.Interface().(T)
+		if !ok {
+			var zero T
+			return zero, fmt.Errorf("rowToStructByDBTag: type assertion to %T failed", zero)
+		}
+		return result, nil
+	}
+
+	result, ok := structVal.Interface().(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("rowToStructByDBTag: type assertion to %T failed", zero)
+	}
+	return result, nil
 }

--- a/internal/stores/user.go
+++ b/internal/stores/user.go
@@ -14,8 +14,6 @@ import (
 	"github.com/tkahng/playground/internal/tools/mapper"
 	"github.com/tkahng/playground/internal/tools/types"
 
-	"github.com/stephenafamo/scan"
-	"github.com/stephenafamo/scan/pgxscan"
 	"github.com/tkahng/playground/internal/database/repository"
 )
 
@@ -367,7 +365,7 @@ func (s *DbUserStore) GetUserInfo(ctx context.Context, email string) (*models.Us
 		User: *user,
 	}
 	roles, err := func() (*rolePermissionClaims, error) {
-		res, err := pgxscan.One(ctx, database.GetContextOrDefaultDbx(ctx, s.db), scan.StructMapper[rolePermissionClaims](), RawGetUserWithAllRolesAndPermissionsByEmail, email)
+		res, err := database.QueryOne[rolePermissionClaims](ctx, s.db, RawGetUserWithAllRolesAndPermissionsByEmail, email)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Removes github.com/stephenafamo/scan v0.7.0. All scan calls are replaced by a custom rowToStructByDBTag scanner that reads "db" struct tags and resolves dot-separated column aliases (e.g. "stripe_customer.id") as nested struct paths — preserving full compatibility with join queries.

- QueryAll/QueryOne use pgx.CollectRows/CollectOneRow + rowToStructByDBTag
- Count/QueryOneSingleColumn/QueryManySingleColumn use pgx.RowTo[T]
- CountOutput.Count gains db:"count" tag so squirrel-based count queries scan correctly
- stores/user.go: pgxscan.One → database.QueryOne