### PR TITLE
feat(admin): add Stripe products/prices sync endpoint and UI

### DIFF
--- a/internal/apis/admin_api_bind.go
+++ b/internal/apis/admin_api_bind.go
@@ -365,6 +365,18 @@ func bindAdminApi(appApi *Api) {
 	// admin permissions delete
 	huma.Register(adminGroup, huma.Operation{OperationID: "admin-permissions-delete", Method: http.MethodDelete, Path: "/permissions/{id}", Summary: "Delete permission", Description: "Delete permission", Tags: []string{"Admin", "Permissions"}, Errors: []int{http.StatusNotFound}, Security: []map[string][]string{{shared.BearerAuthSecurityKey: {}}}}, appApi.AdminPermissionsDelete)
 
+	// admin stripe sync products and prices
+	huma.Register(adminGroup, huma.Operation{
+		OperationID: "admin-stripe-sync",
+		Method:      http.MethodPost,
+		Path:        "/stripe/sync",
+		Summary:     "Sync Stripe products and prices",
+		Description: "Pulls all products and prices from Stripe and upserts them into the local database. Safe to run multiple times.",
+		Tags:        []string{"Admin", "Product", "Stripe"},
+		Errors:      []int{http.StatusInternalServerError},
+		Security:    []map[string][]string{{shared.BearerAuthSecurityKey: {}}},
+	}, appApi.AdminStripeSyncProductsAndPrices)
+
 	// admin stripe subscriptions
 	huma.Register(adminGroup, huma.Operation{OperationID: "admin-stripe-subscriptions", Method: http.MethodGet, Path: "/subscriptions", Summary: "Admin stripe subscriptions", Description: "List of stripe subscriptions", Tags: []string{"Admin", "Subscription", "Stripe"}, Errors: []int{http.StatusNotFound}, Security: []map[string][]string{{shared.BearerAuthSecurityKey: {}}}}, appApi.AdminStripeSubscriptions)
 	// admin stripe subscriptions get

--- a/internal/apis/admin_stripe.go
+++ b/internal/apis/admin_stripe.go
@@ -214,6 +214,31 @@ func (api *Api) AdminStripeProductsPermissionsCreate(ctx context.Context, input 
 	return nil, nil
 }
 
+type AdminStripeSyncOutput struct {
+	Body struct {
+		Message          string `json:"message"`
+		ProductsSynced   bool   `json:"products_synced"`
+		PricesSynced     bool   `json:"prices_synced"`
+	}
+}
+
+func (api *Api) AdminStripeSyncProductsAndPrices(ctx context.Context, _ *struct{}) (*AdminStripeSyncOutput, error) {
+	if err := api.App().Payment().UpsertPriceProductFromStripe(ctx); err != nil {
+		return nil, huma.Error500InternalServerError("Failed to sync Stripe products and prices", err)
+	}
+	return &AdminStripeSyncOutput{
+		Body: struct {
+			Message        string `json:"message"`
+			ProductsSynced bool   `json:"products_synced"`
+			PricesSynced   bool   `json:"prices_synced"`
+		}{
+			Message:        "Stripe products and prices synced successfully",
+			ProductsSynced: true,
+			PricesSynced:   true,
+		},
+	}, nil
+}
+
 func (api *Api) AdminStripeProductsPermissionDelete(ctx context.Context, input *struct {
 	ProductID    string `path:"product-id" required:"true"`
 	PermissionID string `path:"permission-id" required:"true" format:"uuid"`

--- a/internal/apis/admin_stripe_sync_test.go
+++ b/internal/apis/admin_stripe_sync_test.go
@@ -1,0 +1,116 @@
+package apis_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	stripe "github.com/stripe/stripe-go/v82"
+	"github.com/tkahng/playground/internal/apis"
+	"github.com/tkahng/playground/internal/core"
+	"github.com/tkahng/playground/internal/database"
+	"github.com/tkahng/playground/internal/shared"
+	"github.com/tkahng/playground/internal/test"
+)
+
+func TestApi_AdminStripeSyncProductsAndPrices(t *testing.T) {
+	test.SkipIfShort(t)
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		testApi := apis.SetupApi(t, ctx, db)
+		adminUser := core.CreateUserWithOptions(
+			t,
+			testApi.App,
+			core.UserWithEmail("sync-admin@k2dv.io"),
+			core.UserWithPermission(shared.PermissionNameAdmin),
+		)
+		regularUser := core.CreateUserWithOptions(
+			t,
+			testApi.App,
+			core.UserWithEmail("sync-user@k2dv.io"),
+		)
+		adminHeader := core.CreateTokenHeader(t, testApi.App, adminUser.User.Email)
+		regularHeader := core.CreateTokenHeader(t, testApi.App, regularUser.User.Email)
+
+		tests := []apis.ApiScenario{
+			{
+				Name:           "sync - ok as superuser",
+				Method:         http.MethodPost,
+				URL:            "/admin/stripe/sync",
+				ExpectedStatus: http.StatusOK,
+				Headers:        []string{adminHeader},
+				TestAppFactory: func(t testing.TB) *apis.TestApi { return testApi },
+				AfterTestFunc: func(t testing.TB, app *core.BaseApp, scenario *apis.ApiScenario, res *httptest.ResponseRecorder) {
+					var body apis.AdminStripeSyncOutput
+					if err := json.NewDecoder(res.Body).Decode(&body.Body); err != nil {
+						t.Fatalf("decode error: %v", err)
+					}
+					if !body.Body.ProductsSynced {
+						t.Error("expected products_synced=true")
+					}
+					if !body.Body.PricesSynced {
+						t.Error("expected prices_synced=true")
+					}
+					if body.Body.Message == "" {
+						t.Error("expected non-empty message")
+					}
+				},
+			},
+			{
+				Name:            "sync - unauthorized without token",
+				Method:          http.MethodPost,
+				URL:             "/admin/stripe/sync",
+				ExpectedStatus:  http.StatusUnauthorized,
+				ExpectedContent: []string{"Unauthorized"},
+				TestAppFactory:  func(t testing.TB) *apis.TestApi { return testApi },
+			},
+			{
+				Name:            "sync - forbidden for regular user",
+				Method:          http.MethodPost,
+				URL:             "/admin/stripe/sync",
+				ExpectedStatus:  http.StatusForbidden,
+				Headers:         []string{regularHeader},
+				ExpectedContent: []string{"Forbidden"},
+				TestAppFactory:  func(t testing.TB) *apis.TestApi { return testApi },
+			},
+		}
+		for _, tt := range tests {
+			tt.Test(t)
+		}
+	})
+}
+
+func TestApi_AdminStripeSyncProductsAndPrices_ClientError(t *testing.T) {
+	test.SkipIfShort(t)
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		testApi := apis.SetupApi(t, ctx, db)
+		adminUser := core.CreateUserWithOptions(
+			t,
+			testApi.App,
+			core.UserWithEmail("sync-admin-err@k2dv.io"),
+			core.UserWithPermission(shared.PermissionNameAdmin),
+		)
+		adminHeader := core.CreateTokenHeader(t, testApi.App, adminUser.User.Email)
+
+		mockClient := core.ExtractTestPaymentClient(t, testApi.App)
+		mockClient.FindAllProductsFunc = func() ([]*stripe.Product, error) {
+			return nil, &stripe.Error{Msg: "stripe is down"}
+		}
+
+		tests := []apis.ApiScenario{
+			{
+				Name:            "sync - 500 when stripe client fails",
+				Method:          http.MethodPost,
+				URL:             "/admin/stripe/sync",
+				ExpectedStatus:  http.StatusInternalServerError,
+				Headers:         []string{adminHeader},
+				ExpectedContent: []string{"Failed to sync"},
+				TestAppFactory:  func(t testing.TB) *apis.TestApi { return testApi },
+			},
+		}
+		for _, tt := range tests {
+			tt.Test(t)
+		}
+	})
+}

--- a/internal/jobs/poller_test.go
+++ b/internal/jobs/poller_test.go
@@ -7,75 +7,49 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tkahng/playground/internal/conf"
 	"github.com/tkahng/playground/internal/database"
-	"github.com/tkahng/playground/internal/database/repository"
 	"github.com/tkahng/playground/internal/stores"
 )
 
 func TestPoller_Run(t *testing.T) {
-	ctx := context.Background()
-	cfg := conf.ZeroEnvConfig()
-	dbx, err := database.CreateNewQueriesContext(ctx, cfg.Db.GetDatabaseURL())
-	if err != nil {
-		t.Fatalf("failed to create database pool: %v", err)
-	}
-	t.Cleanup(func() {
-		_, err := repository.Job.Delete(ctx, dbx, &map[string]any{})
-		dbx.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	})
-	t.Run("Poller.Run", func(t *testing.T) {
-		wantErr := false
-		wg := &sync.WaitGroup{}
-		args := EmailJobArgs{
-			Recipient: "fail@example.com",
-			Subject:   uuid.NewString(),
-			Body:      "test email body",
-		}
-		testJobs := setupJobs(dbx)
-		testJobs.Worker.WorkFunc = func(ctx context.Context, job *Job[EmailJobArgs]) error {
-			testJobs.Worker.Job = job
-			testJobs.Worker.Success = true
-			return nil
-		}
-		testJobs.UseWg(wg)
-		wg.Add(1)
+	database.WithNewDatabase(t, func(ctx context.Context, dbx database.Dbx) {
+		t.Run("Poller.Run", func(t *testing.T) {
+			wg := &sync.WaitGroup{}
+			args := EmailJobArgs{
+				Recipient: "fail@example.com",
+				Subject:   uuid.NewString(),
+				Body:      "test email body",
+			}
+			testJobs := setupJobs(dbx)
+			testJobs.Worker.WorkFunc = func(ctx context.Context, job *Job[EmailJobArgs]) error {
+				testJobs.Worker.Job = job
+				testJobs.Worker.Success = true
+				return nil
+			}
+			testJobs.UseWg(wg)
+			wg.Add(1)
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-		done := make(chan struct{})
+			go func() {
+				ServeWithPoller(ctx, testJobs.Poller)
+			}()
 
-		// Run poller in background
-		go func() {
-			ServeWithPoller(ctx, testJobs.Poller)
-		}()
-		// tt.args.args, nil, time.Now(), 1
-		if err := testJobs.Manager.Enqueue(ctx, &EnqueueParams{
-			Args:        args,
-			RunAfter:    time.Now(),
-			MaxAttempts: 1,
-		}); (err != nil) != wantErr {
-			t.Errorf("Poller.Run() error = %v, wantErr %v", err, wantErr)
-		}
+			if err := testJobs.Manager.Enqueue(ctx, &EnqueueParams{
+				Args:        args,
+				RunAfter:    time.Now(),
+				MaxAttempts: 1,
+			}); err != nil {
+				t.Errorf("Poller.Run() enqueue error = %v", err)
+			}
 
-		wg.Wait()
-		if !testJobs.Worker.Success {
-			t.Errorf("Poller.Run() job success = %v", testJobs.Worker.Success)
-		}
-		// Cancel poller context
-		close(done)
-		cancel()
-
-		// Optional: Wait for poller shutdown to clean up goroutine
-		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Errorf("poller did not shut down")
-		}
+			wg.Wait()
+			if !testJobs.Worker.Success {
+				t.Errorf("Poller.Run() job success = %v", testJobs.Worker.Success)
+			}
+			cancel()
+		})
 	})
 }
 

--- a/internal/services/payment_service_sync_test.go
+++ b/internal/services/payment_service_sync_test.go
@@ -1,0 +1,85 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v82"
+	"github.com/tkahng/playground/internal/database"
+	"github.com/tkahng/playground/internal/services"
+	"github.com/tkahng/playground/internal/stores"
+)
+
+func TestStripeService_UpsertPriceProductFromStripe(t *testing.T) {
+	t.Run("syncs products and prices from stripe client", func(t *testing.T) {
+		database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+			adpt := stores.NewDbAdapterDecorators(db)
+			client := services.NewMockPaymentClient()
+			svc := services.NewPaymentService(client, adpt)
+
+			err := svc.UpsertPriceProductFromStripe(ctx)
+			require.NoError(t, err)
+
+			products, err := adpt.Product().ListProducts(ctx, &stores.StripeProductFilter{
+				PaginatedInput: stores.PaginatedInput{PerPage: 100},
+			})
+			require.NoError(t, err)
+			assert.Len(t, products, len(services.Products), "all mock products should be upserted")
+
+			prices, err := adpt.Price().ListPrices(ctx, &stores.StripePriceFilter{
+				PaginatedInput: stores.PaginatedInput{PerPage: 100},
+			})
+			require.NoError(t, err)
+			assert.Len(t, prices, len(services.Prices), "all mock prices should be upserted")
+		})
+	})
+
+	t.Run("is idempotent - second sync overwrites without error", func(t *testing.T) {
+		database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+			adpt := stores.NewDbAdapterDecorators(db)
+			client := services.NewMockPaymentClient()
+			svc := services.NewPaymentService(client, adpt)
+
+			require.NoError(t, svc.UpsertPriceProductFromStripe(ctx))
+			require.NoError(t, svc.UpsertPriceProductFromStripe(ctx))
+
+			products, err := adpt.Product().ListProducts(ctx, &stores.StripeProductFilter{
+				PaginatedInput: stores.PaginatedInput{PerPage: 100},
+			})
+			require.NoError(t, err)
+			assert.Len(t, products, len(services.Products))
+		})
+	})
+
+	t.Run("returns error when FindAllProducts fails", func(t *testing.T) {
+		adpt := stores.NewAdapterDecorators()
+		client := services.NewMockPaymentClient()
+		svc := services.NewPaymentService(client, adpt)
+
+		client.FindAllProductsFunc = func() ([]*stripe.Product, error) {
+			return nil, errors.New("stripe unavailable")
+		}
+
+		err := svc.UpsertPriceProductFromStripe(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error when FindAllPrices fails", func(t *testing.T) {
+		adpt := stores.NewAdapterDecorators()
+		client := services.NewMockPaymentClient()
+		svc := services.NewPaymentService(client, adpt)
+
+		client.FindAllProductsFunc = func() ([]*stripe.Product, error) {
+			return []*stripe.Product{}, nil
+		}
+		client.FindAllPricesFunc = func() ([]*stripe.Price, error) {
+			return nil, errors.New("stripe prices unavailable")
+		}
+
+		err := svc.UpsertPriceProductFromStripe(context.Background())
+		assert.Error(t, err)
+	})
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1049,6 +1049,29 @@ export const adminResetUserPassword = async (
   return data;
 };
 
+export const adminStripeSyncProductsAndPrices = async (token: string) => {
+  const response = await fetch("/api/admin/stripe/sync", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new ApiError(
+      body?.detail ?? response.statusText,
+      body?.title ?? "Stripe sync failed",
+      response.status
+    );
+  }
+  return response.json() as Promise<{
+    message: string;
+    products_synced: boolean;
+    prices_synced: boolean;
+  }>;
+};
+
 export const adminStripeProducts = async (
   token: string,
   args: operations["admin-stripe-products"]["parameters"]["query"]

--- a/ui/src/pages/admin/products/products-list.tsx
+++ b/ui/src/pages/admin/products/products-list.tsx
@@ -3,6 +3,15 @@ import { CenteredSpinner } from "@/components/centered-spinner";
 import { DataTable } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -16,21 +25,39 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuthProvider } from "@/hooks/use-auth-provider";
-import { adminStripeProducts } from "@/lib/api";
-import { useQuery } from "@tanstack/react-query";
+import { adminStripeProducts, adminStripeSyncProductsAndPrices } from "@/lib/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PaginationState, Updater } from "@tanstack/react-table";
-import { Ellipsis, Pencil } from "lucide-react";
+import { Ellipsis, Pencil, RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-// import { CreateUserDialog } from "./create-user-dialog";
+import { toast } from "sonner";
 export default function ProductsListPage() {
   const { user } = useAuthProvider();
+  const queryClient = useQueryClient();
+  const [syncDialogOpen, setSyncDialogOpen] = useState(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const pageIndex = parseInt(searchParams.get("page") || "0", 10);
   const pageSize = parseInt(searchParams.get("per_page") || "10", 10);
   const sortBy = searchParams.get("sort_by") || "updated_at";
   const sortOrder = (searchParams.get("sort_order") || "desc") as "asc" | "desc";
+
+  const syncMutation = useMutation({
+    mutationFn: async () => {
+      if (!user?.tokens.access_token) throw new Error("Missing access token");
+      return adminStripeSyncProductsAndPrices(user.tokens.access_token);
+    },
+    onSuccess: () => {
+      toast.success("Stripe products and prices synced successfully");
+      setSyncDialogOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["products-list"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to sync Stripe data");
+      setSyncDialogOpen(false);
+    },
+  });
 
   const onPaginationChange = (updater: Updater<PaginationState>) => {
     const newState =
@@ -70,10 +97,59 @@ export default function ProductsListPage() {
 
   return (
     <div className="space-y-6">
-      <p>
-        Edit product roles and permissions. For more information, visit the
-        stripe dashboard.
-      </p>
+      <div className="flex items-center justify-between">
+        <p>
+          Edit product roles and permissions. For more information, visit the
+          stripe dashboard.
+        </p>
+        <Dialog open={syncDialogOpen} onOpenChange={setSyncDialogOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline" className="gap-2">
+              <RefreshCw className="h-4 w-4" />
+              Sync Stripe Data
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Sync Stripe Products &amp; Prices</DialogTitle>
+              <DialogDescription>
+                This will pull all products and prices from Stripe and upsert
+                them into the local database. Existing records will be
+                overwritten with the latest Stripe data. This action cannot be
+                undone.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="rounded-md bg-yellow-50 border border-yellow-200 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:border-yellow-800 dark:text-yellow-200">
+              Warning: This overwrites local product and price data with data
+              from Stripe. Only proceed if you intend to pull in updates from
+              Stripe.
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setSyncDialogOpen(false)}
+                disabled={syncMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => syncMutation.mutate()}
+                disabled={syncMutation.isPending}
+              >
+                {syncMutation.isPending ? (
+                  <>
+                    <RefreshCw className="h-4 w-4 animate-spin" />
+                    Syncing...
+                  </>
+                ) : (
+                  "Confirm Sync"
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
       <div className="flex items-center gap-2">
         <Select
           value={sortBy}


### PR DESCRIPTION
POST /admin/stripe/sync pulls all products and prices from Stripe and upserts them locally. Superuser-only via existing admin middleware.

Admin products page gets a sync button with a confirmation dialog, spinner state, and toast feedback. Tests cover the service method (success, idempotency, client errors) and the API endpoint (200, 401, 403, 500).