### PR TITLE
feat(rps): enforce one active game per player

### DIFF
--- a/internal/apis/game_rps_test.go
+++ b/internal/apis/game_rps_test.go
@@ -26,21 +26,14 @@ func Test_FindCurrentPlayersRpsGames(t *testing.T) {
 		registeredPlayer := core.MustCreatePlayerWithOptions(t, testApi.App, core.WithPlayerRegistered(true))
 		registeredPlayer2 := core.MustCreatePlayerWithOptions(t, testApi.App, core.WithPlayerRegistered(true))
 		registeredPlayer3 := core.MustCreatePlayerWithOptions(t, testApi.App, core.WithPlayerRegistered(true))
-		for i := range 5 {
-			switch i % 2 {
-			case 0:
-				_ = core.MustCreateGame(t, testApi.App, registeredPlayer.ID, registeredPlayer2.ID, models.RpsParticipantMovePaper)
-			case 1:
-				_ = core.MustCreateGame(t, testApi.App, registeredPlayer2.ID, registeredPlayer.ID, models.RpsParticipantMovePaper)
-			}
+		// Each game must be completed before creating the next: one active game per player.
+		for range 5 {
+			g := core.MustCreateGame(t, testApi.App, registeredPlayer.ID, registeredPlayer2.ID, models.RpsParticipantMovePaper)
+			core.MustCompleteGame(t, testApi.App, g, models.RpsParticipantMoveRock)
 		}
-		for i := range 5 {
-			switch i % 2 {
-			case 0:
-				_ = core.MustCreateGame(t, testApi.App, registeredPlayer3.ID, registeredPlayer2.ID, models.RpsParticipantMovePaper)
-			case 1:
-				_ = core.MustCreateGame(t, testApi.App, registeredPlayer2.ID, registeredPlayer3.ID, models.RpsParticipantMovePaper)
-			}
+		for range 5 {
+			g := core.MustCreateGame(t, testApi.App, registeredPlayer3.ID, registeredPlayer2.ID, models.RpsParticipantMovePaper)
+			core.MustCompleteGame(t, testApi.App, g, models.RpsParticipantMoveRock)
 		}
 		count, err := testApi.App.Adapter().Gaming().CountRpsGames(ctx, nil)
 		assert.NoError(t, err)

--- a/internal/core/test_helpers.go
+++ b/internal/core/test_helpers.go
@@ -31,6 +31,21 @@ func MustCreateGame(t testing.TB, app App, requestingPlayerID, invitingPlayerID 
 	return game
 }
 
+func MustCompleteGame(t testing.TB, app App, game *services.RpsGameWithParticipants, invitedMove models.RpsParticipantMove) *services.RpsGameWithParticipants {
+	t.Helper()
+	ctx := t.Context()
+	completed, err := app.RpsGame().RespondToGameRequest(ctx, &services.GameRequestResponse{
+		InvitedPlayerID: game.InvitedParticipant.PlayerID,
+		GameID:          game.RpsGame.ID,
+		Status:          models.RpsGameStatusCompleted,
+		Move:            invitedMove,
+	})
+	if err != nil {
+		t.Fatalf("MustCompleteGame RespondToGameRequest() error = %v", err)
+	}
+	return completed
+}
+
 func ExtractTestMailer(t testing.TB, testApi App) *mailer.TestMailer {
 	var testMailer *mailer.TestMailer
 	if m, ok := testApi.Mailer().(*mailer.TestMailer); ok {

--- a/internal/services/gaming_rps_game_service.go
+++ b/internal/services/gaming_rps_game_service.go
@@ -87,9 +87,31 @@ type RpsGameRequestInput struct {
 	HostUserID *uuid.UUID
 }
 
+func (d *DbRpsGameService) playerHasActiveGame(ctx context.Context, playerID uuid.UUID) (bool, error) {
+	count, err := d.adapter.Gaming().CountRpsGames(ctx, &stores.RpsGameFilter{
+		ParticipantIds: []uuid.UUID{playerID},
+		Statuses:       []models.RpsGameStatus{models.RpsGameStatusPending},
+	})
+	if err != nil {
+		return false, fmt.Errorf("check active game for player %s: %w", playerID, err)
+	}
+	return count > 0, nil
+}
+
 func (d *DbRpsGameService) RequestGame(ctx context.Context, input *RpsGameRequestInput) (*RpsGameWithParticipants, error) {
 	if input.RequestingPlayerID == input.InvitedPlayerID {
 		return nil, errors.New("cannot challenge yourself")
+	}
+	// Enforce one active game per player.
+	if active, err := d.playerHasActiveGame(ctx, input.RequestingPlayerID); err != nil {
+		return nil, err
+	} else if active {
+		return nil, apierrors.Conflict("you already have an active game in progress")
+	}
+	if active, err := d.playerHasActiveGame(ctx, input.InvitedPlayerID); err != nil {
+		return nil, err
+	} else if active {
+		return nil, apierrors.Conflict("invited player already has an active game in progress")
 	}
 	// Validate betting prerequisites.
 	if input.BetAmount != nil {

--- a/internal/services/gaming_rps_game_service_test.go
+++ b/internal/services/gaming_rps_game_service_test.go
@@ -519,8 +519,12 @@ func TestDbRpsGameService_ExpireGamesAndRefundBets_ContinuesOnPerGameError(t *te
 			stores.WithPlayerEmail("sweep_hostb@example.com"),
 			stores.WithUserID(mustCreateUser(t, ctx, adapter, "sweep_hostb@example.com").ID),
 		)
-		guest := stores.MustCreatePlayer(t, ctx, adapter.Gaming(),
-			stores.WithPlayerEmail("sweep_guest@example.com"),
+		// Separate guests so each host/guest pair doesn't violate the one-active-game constraint.
+		guestA := stores.MustCreatePlayer(t, ctx, adapter.Gaming(),
+			stores.WithPlayerEmail("sweep_guesta@example.com"),
+		)
+		guestB := stores.MustCreatePlayer(t, ctx, adapter.Gaming(),
+			stores.WithPlayerEmail("sweep_guestb@example.com"),
 		)
 
 		mustFundPlayerWallet(t, ctx, adapter, ledger, hostA.UserID, 500)
@@ -530,7 +534,7 @@ func TestDbRpsGameService_ExpireGamesAndRefundBets_ContinuesOnPerGameError(t *te
 
 		gameA, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
 			RequestingPlayerID:   hostA.ID,
-			InvitedPlayerID:      guest.ID,
+			InvitedPlayerID:      guestA.ID,
 			RequestingPlayerMove: models.RpsParticipantMoveRock,
 			DurationSeconds:      1,
 			BetAmount:            &betAmount,
@@ -542,7 +546,7 @@ func TestDbRpsGameService_ExpireGamesAndRefundBets_ContinuesOnPerGameError(t *te
 
 		gameB, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
 			RequestingPlayerID:   hostB.ID,
-			InvitedPlayerID:      guest.ID,
+			InvitedPlayerID:      guestB.ID,
 			RequestingPlayerMove: models.RpsParticipantMoveRock,
 			DurationSeconds:      1,
 			BetAmount:            &betAmount,
@@ -757,6 +761,68 @@ func TestDbRpsGameService_PlayerCanPlayWithPlayer_AcceptedFriendship(t *testing.
 		}
 		if !canPlay {
 			t.Error("PlayerCanPlayWithPlayer() = false, want true for accepted friendship")
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_BlockedWhenRequesterHasActiveGame(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("active_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("active_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("active_p3@example.com"))
+
+		_, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p3.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err == nil {
+			t.Fatal("expected error when requester already has active game, got nil")
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_BlockedWhenInvitedHasActiveGame(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invactive_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invactive_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invactive_p3@example.com"))
+
+		_, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p3.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err == nil {
+			t.Fatal("expected error when invited player already has active game, got nil")
 		}
 	})
 }

--- a/internal/services/gaming_rps_game_service_test.go
+++ b/internal/services/gaming_rps_game_service_test.go
@@ -793,6 +793,9 @@ func TestDbRpsGameService_RequestGame_BlockedWhenRequesterHasActiveGame(t *testi
 		if err == nil {
 			t.Fatal("expected error when requester already has active game, got nil")
 		}
+		if err.Error() != "you already have an active game in progress" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
 	})
 }
 
@@ -823,6 +826,169 @@ func TestDbRpsGameService_RequestGame_BlockedWhenInvitedHasActiveGame(t *testing
 		})
 		if err == nil {
 			t.Fatal("expected error when invited player already has active game, got nil")
+		}
+		if err.Error() != "invited player already has an active game in progress" {
+			t.Errorf("unexpected error message: %q", err.Error())
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_AllowedAfterRequesterGameCompleted(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcomp_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcomp_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcomp_p3@example.com"))
+
+		first, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+		_, err = rpsService.RespondToGameRequest(ctx, &GameRequestResponse{
+			InvitedPlayerID: p2.ID,
+			GameID:          first.RpsGame.ID,
+			Status:          models.RpsGameStatusCompleted,
+			Move:            models.RpsParticipantMoveRock,
+		})
+		if err != nil {
+			t.Fatalf("RespondToGameRequest() error = %v", err)
+		}
+
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p3.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("second RequestGame() after completion should succeed, got error: %v", err)
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_AllowedAfterRequesterGameCancelled(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcanc_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcanc_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("reqcanc_p3@example.com"))
+
+		first, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+		_, err = rpsService.RespondToGameRequest(ctx, &GameRequestResponse{
+			InvitedPlayerID: p2.ID,
+			GameID:          first.RpsGame.ID,
+			Status:          models.RpsGameStatusCancelled,
+		})
+		if err != nil {
+			t.Fatalf("RespondToGameRequest(cancel) error = %v", err)
+		}
+
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p3.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("second RequestGame() after cancellation should succeed, got error: %v", err)
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_AllowedAfterInvitedGameCompleted(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcomp_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcomp_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcomp_p3@example.com"))
+
+		first, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+		_, err = rpsService.RespondToGameRequest(ctx, &GameRequestResponse{
+			InvitedPlayerID: p2.ID,
+			GameID:          first.RpsGame.ID,
+			Status:          models.RpsGameStatusCompleted,
+			Move:            models.RpsParticipantMoveScissors,
+		})
+		if err != nil {
+			t.Fatalf("RespondToGameRequest() error = %v", err)
+		}
+
+		// p2 was the invited player — should now be free to join a new game
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p3.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("RequestGame() inviting p2 after completion should succeed, got error: %v", err)
+		}
+	})
+}
+
+func TestDbRpsGameService_RequestGame_AllowedAfterInvitedGameCancelled(t *testing.T) {
+	database.WithNewTestTx(t, func(ctx context.Context, db database.Dbx) {
+		adapter := stores.NewDbAdapterDecorators(db)
+		rpsService := NewDbRpsGameService(adapter, NewDbBettingService(adapter, NewDbLedgerService(adapter)))
+
+		p1 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcanc_p1@example.com"))
+		p2 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcanc_p2@example.com"))
+		p3 := stores.MustCreatePlayer(t, ctx, adapter.Gaming(), stores.WithPlayerEmail("invcanc_p3@example.com"))
+
+		first, err := rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p1.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("first RequestGame() error = %v", err)
+		}
+		_, err = rpsService.RespondToGameRequest(ctx, &GameRequestResponse{
+			InvitedPlayerID: p2.ID,
+			GameID:          first.RpsGame.ID,
+			Status:          models.RpsGameStatusCancelled,
+		})
+		if err != nil {
+			t.Fatalf("RespondToGameRequest(cancel) error = %v", err)
+		}
+
+		// p2 was the invited player — should now be free to join a new game
+		_, err = rpsService.RequestGame(ctx, &RpsGameRequestInput{
+			RequestingPlayerID:   p3.ID,
+			InvitedPlayerID:      p2.ID,
+			RequestingPlayerMove: models.RpsParticipantMoveRock,
+			DurationSeconds:      3600,
+		})
+		if err != nil {
+			t.Fatalf("RequestGame() inviting p2 after cancellation should succeed, got error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- A player can no longer be the requester or invitee in more than one pending RPS game at a time
- Returns `409 Conflict` with a descriptive message for both cases
- Fixed existing expiry-sweep test that created two simultaneous games with the same guest player (now uses separate guests)
- Added two new tests covering both blocked paths

## Test plan

- [ ] `TestDbRpsGameService_RequestGame_BlockedWhenRequesterHasActiveGame` — requester already has pending game
- [ ] `TestDbRpsGameService_RequestGame_BlockedWhenInvitedHasActiveGame` — invited player already has pending game
- [ ] All existing RPS service tests still pass