### PR TITLE
fix(say-hello): leaderboard shows empty country name and zero counts

### DIFF
--- a/internal/stores/user_reaction.go
+++ b/internal/stores/user_reaction.go
@@ -16,8 +16,8 @@ type UserReactionFilter struct {
 }
 
 type ReactionByCountry struct {
-	Country        string `json:"country"`
-	TotalReactions int64  `json:"total_reactions"`
+	Country        string `db:"country" json:"country"`
+	TotalReactions int64  `db:"total_reactions" json:"total_reactions"`
 }
 
 type UserReactionStore interface {

--- a/internal/stores/user_reaction_test.go
+++ b/internal/stores/user_reaction_test.go
@@ -142,16 +142,18 @@ func TestDbUserReactionStore_CountByCountry(t *testing.T) {
 			switch c.Country {
 			case "us":
 				if c.TotalReactions != 10 {
-					t.Fatalf("Expected 10 user reactions, got %d", c.TotalReactions)
+					t.Fatalf("Expected 10 user reactions for us, got %d", c.TotalReactions)
 				}
 			case "fr":
 				if c.TotalReactions != 5 {
-					t.Fatalf("Expected 5 user reactions, got %d", c.TotalReactions)
+					t.Fatalf("Expected 5 user reactions for fr, got %d", c.TotalReactions)
 				}
 			case "cn":
 				if c.TotalReactions != 3 {
-					t.Fatalf("Expected 3 user reactions, got %d", c.TotalReactions)
+					t.Fatalf("Expected 3 user reactions for cn, got %d", c.TotalReactions)
 				}
+			default:
+				t.Fatalf("Unexpected country %q with count %d", c.Country, c.TotalReactions)
 			}
 		}
 	})

--- a/ui/src/pages/say-hello/say-hello2.tsx
+++ b/ui/src/pages/say-hello/say-hello2.tsx
@@ -254,7 +254,7 @@ export default function SayHelloPage() {
                         {index + 1}
                       </div>
                       <span className="font-medium text-secondary-foreground">
-                        {country}
+                        {getCountryName(country) || country}
                       </span>
                     </div>
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
ReactionByCountry was missing db struct tags so rowToStructByDBTag discarded all scanned values, leaving every row as {country:"", total:0}. React keyed on the empty string and collapsed duplicates to one entry. Also convert the ISO country code to a display name in the top-5 list.