### PR TITLE
fix(test): non-null assert result[0] in task-comment test

### DIFF
--- a/ui/src/lib/__tests__/task-comment-queries.test.ts
+++ b/ui/src/lib/__tests__/task-comment-queries.test.ts
@@ -53,7 +53,7 @@ describe("listTaskComments", () => {
       }),
     );
     expect(result).toHaveLength(1);
-    expect(result[0].content).toBe("hello world");
+    expect(result[0]!.content).toBe("hello world");
   });
 
   it("returns empty array when data is null", async () => {


### PR DESCRIPTION
## Summary
- `TS2532`: `result[0]` access in `task-comment-queries.test.ts:56` typed as possibly `undefined`
- Add `!` non-null assertion to satisfy TypeScript strict check
- Unblocks Docker build (`react-build` step was failing with exit code 2)

## Test plan
- [ ] `npm run build` in `ui/` succeeds without TS errors
- [ ] Existing test behavior unchanged