### PR TITLE
feat(rps): reduce house cooldown from 5m to 30s

### DIFF
--- a/internal/services/gaming_rps_game_service.go
+++ b/internal/services/gaming_rps_game_service.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HouseMaxBet         int64         = 500
-	HouseCooldown       time.Duration = 30 * time.Second
+	HouseCooldown       time.Duration = 3 * time.Second
 	HouseWinsMessage                  = "House always wins."
 	GameDurationSeconds int64         = 3 * 24 * 60 * 60 // 3 days
 )

--- a/internal/services/gaming_rps_game_service.go
+++ b/internal/services/gaming_rps_game_service.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HouseMaxBet         int64         = 500
-	HouseCooldown       time.Duration = 5 * time.Minute
+	HouseCooldown       time.Duration = 30 * time.Second
 	HouseWinsMessage                  = "House always wins."
 	GameDurationSeconds int64         = 3 * 24 * 60 * 60 // 3 days
 )


### PR DESCRIPTION
## Summary

- Reduces `HouseCooldown` from 5 minutes to 30 seconds
- Players can replay against the house casually without long waits
- 30s still prevents rapid-fire abuse / bot farming

## Test plan

- [ ] All existing `TestChallengeHouse_*` tests pass (verified locally)
- [ ] Play against house in UI — confirm you can replay after ~30s
- [ ] Confirm second immediate attempt is still blocked with cooldown message